### PR TITLE
Added  "/** OR /*" statement into multiline miltilineComment regexp

### DIFF
--- a/tasks/stripcomments.js
+++ b/tasks/stripcomments.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('comments', 'Remove comments from production code', function() {
 
-    var multilineComment = /\/\*\*[^!][\s\S]*?\*\/\n/gm;
+    var multilineComment = /\/[\*\*|\*][^!][\s\S]*?\*\/\n/gm;
     var singleLineComment = /^\s*\t*(\/\/)[^\n\r]*[\n\r]/gm;
 
     var options = this.options({


### PR DESCRIPTION
Fix for https://github.com/kkemple/grunt-stripcomments/issues/8
With original regexp only /** bla-bla-bla */ comments are affected. We need /* bla-bla-bla */ too.